### PR TITLE
Fix updater install flow when no update is available

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -184,8 +184,10 @@ export const downloadAndInstall = async (
     percent: number;
   }) => void,
 ): Promise<void> => {
-  const update = await check();
-  if (!update) throw new Error("No update available");
+  const update = await check({
+    headers: { "Accept-Encoding": "gzip, deflate" },
+  });
+  if (!update?.available) throw new Error("No update available");
 
   let downloaded = 0;
   let contentLength = 0;


### PR DESCRIPTION
### Motivation
- Prevent the updater from attempting to download/install when the updater response indicates no update is available and align `downloadAndInstall` request headers with `checkUpdate` for consistent behavior.

### Description
- Modified `src/lib/api.ts` to call `check({ headers: { "Accept-Encoding": "gzip, deflate" } })` inside `downloadAndInstall` and changed the guard from `if (!update)` to `if (!update?.available)` to avoid running installation when no update is available.

### Testing
- Ran `pnpm lint` which completed successfully.
- Ran `cargo test` in `src-tauri`, which failed during native dependency resolution because the system `glib-2.0` development library is missing (error in `glib-sys`), so Rust tests could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032e8adbec8321824d5d304cad5a79)